### PR TITLE
fix silent directory removal

### DIFF
--- a/conda/cli/main_remove.py
+++ b/conda/cli/main_remove.py
@@ -159,6 +159,10 @@ def execute(args, parser):
 
     if plan.nothing_to_do(actions):
         if args.all:
+            print()
+            print("Remove all packages in environment %s:\n" % prefix)
+            if not args.json:
+                confirm_yn(args)
             rm_rf(prefix)
 
             if args.json:


### PR DESCRIPTION
By default conda cli looks for environments in the current directory as a last resort.
So, if we issue 'conda remove -n name --all' and 'name' is found in the current directory (e.g., $HOME) conda 4.1.x will proceed with the removal of this directory and all of its contents without asking for confirmation.
